### PR TITLE
Check if the input file exists

### DIFF
--- a/atsas_pipelines/run.py
+++ b/atsas_pipelines/run.py
@@ -85,6 +85,14 @@ def run_with_dask(client, exec_name, input_file, prefix='test', symmetry='P1',
 
     Report bugs to <atsas@embl-hamburg.de>.
     """
+    # Check if the input file exists, is actually a file, not a directory, and
+    # has correct read permissions.
+    try:
+        with open(input_file, 'r'):
+            ...
+    except Exception as e:
+        raise e
+
     futures = []
     for i in range(n_repeats):
         future = client.submit(run_command,

--- a/atsas_pipelines/run.py
+++ b/atsas_pipelines/run.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from .utils import find_executable
@@ -85,6 +86,12 @@ def run_with_dask(client, exec_name, input_file, prefix='test', symmetry='P1',
 
     Report bugs to <atsas@embl-hamburg.de>.
     """
+    # We have to make sure we are working with the absolute paths, as the
+    # relative paths may be different in the eyes of a client and the Dask
+    # SLURM scheduler.
+    if not os.path.isabs(input_file):
+        input_file = os.path.abspath(input_file)
+
     # Check if the input file exists, is actually a file, not a directory, and
     # has correct read permissions.
     try:


### PR DESCRIPTION
Addresses the following item from #9:
> - [ ] check the input file permissions before running, and report it correctly if the permissions are wrong